### PR TITLE
Ion variables can not be set via CONSTANT block (compatibility with upcoming neuron release)

### DIFF
--- a/dbbs_mod_collection/mod/glia__dbbs_mod_collection__cdp5__0.mod
+++ b/dbbs_mod_collection/mod/glia__dbbs_mod_collection__cdp5__0.mod
@@ -101,7 +101,7 @@ ASSIGNED {
 	vrat	(1)	
 }
 
-CONSTANT { cao = 2	(mM) }
+: CONSTANT { cao = 2	(mM) }
 
 STATE {
 	: ca[0] is equivalent to cai

--- a/dbbs_mod_collection/mod/glia__dbbs_mod_collection__cdp5__0.mod
+++ b/dbbs_mod_collection/mod/glia__dbbs_mod_collection__cdp5__0.mod
@@ -97,11 +97,10 @@ ASSIGNED {
 	parea     (um)     : pump area per unit length
 	parea2	  (um)
 	cai       (mM)
+	cao       (mM)
 	mgi	(mM)
 	vrat	(1)	
 }
-
-: CONSTANT { cao = 2	(mM) }
 
 STATE {
 	: ca[0] is equivalent to cai

--- a/dbbs_mod_collection/mod/glia__dbbs_mod_collection__cdp5__CAM.mod
+++ b/dbbs_mod_collection/mod/glia__dbbs_mod_collection__cdp5__CAM.mod
@@ -135,7 +135,7 @@ ASSIGNED {
 	icazz (nA)
 }
 
-CONSTANT { cao = 2	(mM) }
+: CONSTANT { cao = 2	(mM) }
 
 STATE {
 	: ca[0] is equivalent to cai

--- a/dbbs_mod_collection/mod/glia__dbbs_mod_collection__cdp5__CAM.mod
+++ b/dbbs_mod_collection/mod/glia__dbbs_mod_collection__cdp5__CAM.mod
@@ -128,14 +128,13 @@ ASSIGNED {
 	parea     (um)     : pump area per unit length
 	parea2	  (um)
 	cai       (mM)
+	cao       (mM)
 	mgi	(mM)
 	vrat	(1)
 	nr2ai  (mM)
 	nr2bi  (mM)
 	icazz (nA)
 }
-
-: CONSTANT { cao = 2	(mM) }
 
 STATE {
 	: ca[0] is equivalent to cai

--- a/dbbs_mod_collection/mod/glia__dbbs_mod_collection__cdp5__CAM_GoC.mod
+++ b/dbbs_mod_collection/mod/glia__dbbs_mod_collection__cdp5__CAM_GoC.mod
@@ -120,12 +120,11 @@ ASSIGNED {
 	parea     (um)     : pump area per unit length
 	parea2	  (um)
 	cai       (mM)
+	cao       (mM)
 	mgi	(mM)
 	vrat	(1)	
         icazz (nA)
 }
-
-: CONSTANT { cao = 2	(mM) }
 
 STATE {
 	: ca[0] is equivalent to cai

--- a/dbbs_mod_collection/mod/glia__dbbs_mod_collection__cdp5__CAM_GoC.mod
+++ b/dbbs_mod_collection/mod/glia__dbbs_mod_collection__cdp5__CAM_GoC.mod
@@ -125,7 +125,7 @@ ASSIGNED {
         icazz (nA)
 }
 
-CONSTANT { cao = 2	(mM) }
+: CONSTANT { cao = 2	(mM) }
 
 STATE {
 	: ca[0] is equivalent to cai

--- a/dbbs_mod_collection/mod/glia__dbbs_mod_collection__cdp5__CR.mod
+++ b/dbbs_mod_collection/mod/glia__dbbs_mod_collection__cdp5__CR.mod
@@ -102,7 +102,7 @@ ASSIGNED {
 	vrat	(1)	
 }
 
-CONSTANT { cao = 2	(mM) }
+: CONSTANT { cao = 2	(mM) }
 
 STATE {
 	: ca[0] is equivalent to cai

--- a/dbbs_mod_collection/mod/glia__dbbs_mod_collection__cdp5__CR.mod
+++ b/dbbs_mod_collection/mod/glia__dbbs_mod_collection__cdp5__CR.mod
@@ -98,11 +98,10 @@ ASSIGNED {
 	parea     (um)     : pump area per unit length
 	parea2	  (um)
 	cai       (mM)
+	cao       (mM)
 	mgi	(mM)
 	vrat	(1)	
 }
-
-: CONSTANT { cao = 2	(mM) }
 
 STATE {
 	: ca[0] is equivalent to cai


### PR DESCRIPTION
* Setting ionic variables like `cao` in the `CONSTANT` block had no effect.
* For details, see https://github.com/neuronsimulator/nrn/pull/1955
* This will be an error in future neuron v9 and with the latest neuron-nightly pypi package.
* As setting cao from MOD file had no effect, simply comment / remove this (?)