### PR TITLE
Avoid declaring RANGE variables with same name as function

### DIFF
--- a/dbbs_mod_collection/mod/glia__dbbs_mod_collection__HCN1__golgi.mod
+++ b/dbbs_mod_collection/mod/glia__dbbs_mod_collection__HCN1__golgi.mod
@@ -15,7 +15,7 @@ SUFFIX glia__dbbs_mod_collection__HCN1__golgi
 	NONSPECIFIC_CURRENT ih
 	RANGE Q10_diff,Q10_channel,gbar_Q10, ic
 	RANGE o_fast_inf, o_slow_inf, tau_f, tau_s, Erev
-	RANGE gbar,r,g, o
+	RANGE gbar, g, o
 }       
         
 UNITS {

--- a/dbbs_mod_collection/mod/glia__dbbs_mod_collection__Na__granule_cell.mod
+++ b/dbbs_mod_collection/mod/glia__dbbs_mod_collection__Na__granule_cell.mod
@@ -8,7 +8,7 @@ NEURON {
 SUFFIX glia__dbbs_mod_collection__Na__granule_cell
 	USEION na READ ena WRITE ina
 	RANGE gnabar, ina, g
-	RANGE alfa, beta, gamma, delta, epsilon, teta, Con, Coff, Oon, Ooff
+	RANGE gamma, delta, epsilon, Con, Coff, Oon, Ooff
 	RANGE Aalfa, Valfa, Abeta, Vbeta, Ateta, Vteta, Agamma, Adelta, Aepsilon, ACon, ACoff, AOon, AOoff
 	RANGE n1,n2,n3,n4, alpha_d, beta_d, teta_d
 }

--- a/dbbs_mod_collection/mod/glia__dbbs_mod_collection__Na__granule_cell_FHF.mod
+++ b/dbbs_mod_collection/mod/glia__dbbs_mod_collection__Na__granule_cell_FHF.mod
@@ -11,7 +11,7 @@ NEURON {
 SUFFIX glia__dbbs_mod_collection__Na__granule_cell_FHF
 	USEION na READ ena WRITE ina
 	RANGE gnabar, ina, g
-	RANGE alfa, beta, gamma, delta, epsilon, teta, Con, Coff, Oon, Ooff, Lon, Loff
+	RANGE gamma, delta, epsilon, Con, Coff, Oon, Ooff, Lon, Loff
 	RANGE Aalfa, Valfa, Abeta, Vbeta, Ateta, Vteta, Agamma, Adelta, Aepsilon, ACon, ACoff, AOon, AOoff
 	RANGE n1,n2,n3,n4
 }


### PR DESCRIPTION
* Remove extra/unused variables with conflicting types (this will be error in upcoming release) 
* See https://github.com/neuronsimulator/nrn/pull/1992 for details
